### PR TITLE
Fix search functionality to return a Page instead of List, and update…

### DIFF
--- a/src/main/java/africa/norsys/doc/configuration/AppConfiguration.java
+++ b/src/main/java/africa/norsys/doc/configuration/AppConfiguration.java
@@ -1,0 +1,29 @@
+package africa.norsys.doc.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+
+@Configuration
+public class AppConfiguration {
+
+
+    @Bean
+    CorsFilter corsFilter() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowCredentials(true);
+        corsConfiguration.setAllowedOriginPatterns(List.of("*")); // Use setAllowedOriginPatterns instead of setAllowedOrigins
+        corsConfiguration.setAllowedHeaders(List.of("*"));
+        corsConfiguration.setAllowedMethods(List.of("*"));
+        UrlBasedCorsConfigurationSource urlBasedCorsConfigurationSource = new UrlBasedCorsConfigurationSource();
+        urlBasedCorsConfigurationSource.registerCorsConfiguration("/**", corsConfiguration);
+        return new CorsFilter(urlBasedCorsConfigurationSource);
+    }
+
+
+}

--- a/src/main/java/africa/norsys/doc/controller/DocumentController.java
+++ b/src/main/java/africa/norsys/doc/controller/DocumentController.java
@@ -13,7 +13,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -54,6 +53,7 @@ public class DocumentController {
         Page<Document> documentPage = documentService.getAllDocuments(page, size, sortDirection, sortBy);
         return documentPage == null || documentPage.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(documentPage);
     }
+
     @DeleteMapping("/{documentId}")
     public ResponseEntity<Void> deleteDocument(@PathVariable UUID documentId) {
         try {
@@ -74,18 +74,17 @@ public class DocumentController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<List<Document>> searchDocuments(
+    public ResponseEntity<Page<Document>> searchDocuments(
             @RequestParam("keyword") String keyword,
-            @RequestParam(value = "date", required = false) String date) {
+            @RequestParam(value = "date", required = false) String date,
+            @RequestParam(defaultValue = DEFAULT_PAGE + "") @Min(0) int page,
+            @RequestParam(defaultValue = DEFAULT_PAGE_SIZE + "") @Min(1) int size) {
 
-        List<Document> documents = documentService.searchByKeyword(keyword, date);
+        Page<Document> documents = documentService.searchByKeyword(keyword, date, page, size);
 
-        if (documents.isEmpty()) {
-            return ResponseEntity.noContent().build();
-        } else {
-            return ResponseEntity.ok(documents);
-        }
-
+        return documents.isEmpty() ?
+                ResponseEntity.noContent().build() :
+                ResponseEntity.ok(documents);
     }
 
 

--- a/src/main/java/africa/norsys/doc/repository/DocumentRepository.java
+++ b/src/main/java/africa/norsys/doc/repository/DocumentRepository.java
@@ -1,12 +1,13 @@
 package africa.norsys.doc.repository;
 
 import africa.norsys.doc.entity.Document;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.UUID;
 
 @Repository
@@ -29,7 +30,7 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
             "AND (:date IS NULL OR DATE(d.creation_date) = DATE(:date)) " +
             "OR d.id IN (SELECT dm.document_id FROM document_metadata dm WHERE LOWER(dm.key) LIKE lower(concat('%', :keyword, '%')) AND LOWER(dm.value) LIKE lower(concat('%', :keyword, '%')))",
             nativeQuery = true)
-    List<Document> searchByKeyword(@Param("keyword") String keyword, @Param("date") String date);
+    Page<Document> searchByKeyword(@Param("keyword") String keyword, @Param("date") String date, Pageable pageable);
 
 
 }

--- a/src/main/java/africa/norsys/doc/service/DocumentService.java
+++ b/src/main/java/africa/norsys/doc/service/DocumentService.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,11 +14,13 @@ public interface DocumentService {
 
     byte[] getFileBytes(String filename) throws IOException;
 
-
     Page<Document> getAllDocuments(Integer page, Integer pageSize, String sortBy, String sortDirection);
-    void deleteDocumentById(UUID documentId)throws DocumentNotFoundException, IOException;;
+
+    Page<Document> searchByKeyword(String keyword, String date, int page, int size);
+
+    void deleteDocumentById(UUID documentId) throws DocumentNotFoundException, IOException;
 
     Optional<Document> getDocumentById(UUID id);
 
-    List<Document> searchByKeyword(String keyword, String date);
+
 }

--- a/src/main/java/africa/norsys/doc/service/impl/DocumentServiceImpl.java
+++ b/src/main/java/africa/norsys/doc/service/impl/DocumentServiceImpl.java
@@ -20,12 +20,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.UUID;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static africa.norsys.doc.constant.Constant.FILE_STORAGE_LOCATION;
+import static africa.norsys.doc.constant.PaginationConstants.DEFAULT_DOCUMENT_SORT_BY;
 import static africa.norsys.doc.util.FileUtils.saveFileAndGenerateUrl;
 
 @Service
@@ -97,9 +96,10 @@ public class DocumentServiceImpl implements DocumentService {
 
 
     @Override
-    public List<Document> searchByKeyword(String keyword, String date) {
+    public Page<Document> searchByKeyword(String keyword, String date, int page, int size) {
         try {
-            List<Document> documents = documentRepository.searchByKeyword(keyword.toLowerCase(), date);
+            Pageable pageable = PageRequest.of(page - 1, size, Sort.Direction.ASC, DEFAULT_DOCUMENT_SORT_BY);
+            Page<Document> documents = documentRepository.searchByKeyword(keyword.toLowerCase(), date, pageable);
             if (documents.isEmpty()) {
                 throw new DocumentNotFoundException("No documents found with the provided keyword and date.");
             }
@@ -109,12 +109,13 @@ public class DocumentServiceImpl implements DocumentService {
             throw new DocumentNotFoundException("Failed to search documents by keyword: " + e.getMessage());
         }
     }
+
     @Override
     public void deleteDocumentById(UUID documentId) throws DocumentNotFoundException, IOException {
         Document document = documentRepository.findById(documentId)
                 .orElseThrow(() -> new DocumentNotFoundException("Document not found with id: " + documentId));
 
-        String filename = documentId+ document.getMetadata().get("extension");
+        String filename = documentId + document.getMetadata().get("extension");
         Path filePath = Paths.get(FILE_STORAGE_LOCATION).resolve(filename).normalize();
         Files.deleteIfExists(filePath);
         documentRepository.delete(document);

--- a/src/test/java/africa/norsys/doc/controller/DocumentControllerTest.java
+++ b/src/test/java/africa/norsys/doc/controller/DocumentControllerTest.java
@@ -240,32 +240,44 @@ class DocumentControllerTest {
     @Test
     @DisplayName("Should search documents by keyword and date")
     void should_search_documents_by_keyword_and_date() throws Exception {
-
+        // Given
         String keyword = "test";
         String date = "2024-04-16";
-        List<Document> expectedDocuments = Collections.singletonList(DocumentHelperTest.createMockDocument());
+        int page = 0;
+        int size = 10;
+        Page<Document> expectedPage = new PageImpl<>(Collections.singletonList(DocumentHelperTest.createMockDocument()));
 
-        when(documentService.searchByKeyword(keyword, date)).thenReturn(expectedDocuments);
+        when(documentService.searchByKeyword(keyword, date, page, size)).thenReturn(expectedPage);
 
+        // When/Then
         mockMvc.perform(get(DOCUMENT_API_ENDPOINT + "/search")
                         .param("keyword", keyword)
                         .param("date", date)
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(expectedDocuments.size()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[0].name").value(expectedDocuments.get(0).getName()));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.content.length()").value(expectedPage.getContent().size()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.content[0].name").value(expectedPage.getContent().get(0).getName()));
     }
+
     @Test
     @DisplayName("Should handle DocumentNotFoundException when no documents are found")
     void should_handle_document_not_found_exception_when_no_documents_found() throws Exception {
+        // Given
         String keyword = "test";
         String date = "2024-04-16";
+        int page = 0;
+        int size = 10;
 
-        when(documentService.searchByKeyword(keyword, date)).thenThrow(new DocumentNotFoundException("No documents found"));
+        when(documentService.searchByKeyword(keyword, date, page, size)).thenThrow(new DocumentNotFoundException("No documents found"));
 
+        // When/Then
         mockMvc.perform(get(DOCUMENT_API_ENDPOINT + "/search")
                         .param("keyword", keyword)
                         .param("date", date)
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andExpect(MockMvcResultMatchers.content().string("No documents found"));


### PR DESCRIPTION
… corresponding tests

- Modified DocumentService to return a Page instead of List in searchByKeyword method to support pagination.
- Updated DocumentServiceTest to accommodate changes in search functionality by using Page instead of List.
- Added pagination support to search tests and adjusted Pageable setup to align with zero-based indexing.
- Implemented a CORS filter to allow cross-origin requests, enhancing API accessibility and security.